### PR TITLE
refactor: extract schemas to src/schemas/ package

### DIFF
--- a/src/agents/auditor.py
+++ b/src/agents/auditor.py
@@ -2,58 +2,16 @@ import re
 from typing import Literal
 
 from langfuse import observe
-from pydantic import BaseModel
 
-
-class SentenceHit(BaseModel):
-    sentence_id: str
-    text: str
-    matched_words: list[str]
-    tier: int  # 1, 2, or 3
-
-
-class LexicalSummary(BaseModel):
-    tier_1_hits: list[str]            # all tier-1 words found (article-level)
-    tier_2_clusters: list[list[str]]  # paragraph-level clusters
-    tier_3_density: float             # ratio: tier-3 words / total words
-
-
-class LexicalWordReport(BaseModel):
-    lexical_summary: LexicalSummary
-    sentence_hits: list[SentenceHit]
-
-
-class SubAgentFinding(BaseModel):
-    sentence_id: str
-    text: str
-    patterns_found: list[str]
-    severity: Literal["low", "medium", "high"]
-    suggested_fix: str
-
-
-class SubAgentReport(BaseModel):
-    category: Literal["lexical", "structural", "tonal", "rhythmic"]
-    findings: list[SubAgentFinding]
-
-
-class FlaggedSentence(BaseModel):
-    sentence_id: str
-    text: str
-    labels: dict[str, list[str]]     # {category: [pattern names]}
-    suggested_fixes: dict[str, str]  # {category: suggested fix}
-    severity: Literal["low", "medium", "high"]
-    is_flagged: bool
-
-
-class AuditReport(BaseModel):
-    article_id: str
-    model: str
-    verdict: Literal["patch", "structural_rewrite_needed"]
-    flag_count: int
-    category_count: int
-    lexical_summary: LexicalSummary
-    sub_reports: dict[str, SubAgentReport]
-    flagged_sentences: list[FlaggedSentence]
+from src.schemas import (
+    SentenceHit,
+    LexicalSummary,
+    LexicalWordReport,
+    SubAgentFinding,
+    SubAgentReport,
+    FlaggedSentence,
+    AuditReport,
+)
 
 
 class AuditorAgent:

--- a/src/agents/rewriter.py
+++ b/src/agents/rewriter.py
@@ -1,21 +1,6 @@
 from langfuse import observe
-from pydantic import BaseModel
 
-from src.agents.auditor import FlaggedSentence
-
-
-class RewriteResult(BaseModel):
-    sentence_id: str
-    original: str
-    rewritten: str
-    change_summary: str
-
-
-class RewriteReport(BaseModel):
-    article_id: str
-    model: str
-    rewrites: list[RewriteResult]
-    full_rewritten_text: str
+from src.schemas import FlaggedSentence, RewriteResult, RewriteReport
 
 
 class RewriterAgent:

--- a/src/detectors/lexical.py
+++ b/src/detectors/lexical.py
@@ -2,7 +2,7 @@ import re
 
 from config.settings import settings
 from config.taxonomy import TIER_1, TIER_2, TIER_3
-from src.agents.auditor import LexicalSummary, LexicalWordReport, SentenceHit
+from src.schemas import LexicalSummary, LexicalWordReport, SentenceHit
 
 
 class PythonLexicalDetector:

--- a/src/detectors/llm_lexical.py
+++ b/src/detectors/llm_lexical.py
@@ -5,7 +5,7 @@ from langfuse import observe
 from openai import OpenAI
 from pydantic import BaseModel
 
-from src.agents.auditor import SubAgentFinding, SubAgentReport
+from src.schemas import SubAgentFinding, SubAgentReport
 
 
 class _FindingsList(BaseModel):

--- a/src/detectors/llm_rhythmic.py
+++ b/src/detectors/llm_rhythmic.py
@@ -5,7 +5,7 @@ from langfuse import observe
 from openai import OpenAI
 from pydantic import BaseModel
 
-from src.agents.auditor import SubAgentFinding, SubAgentReport
+from src.schemas import SubAgentFinding, SubAgentReport
 
 
 class _FindingsList(BaseModel):

--- a/src/detectors/llm_structural.py
+++ b/src/detectors/llm_structural.py
@@ -5,7 +5,7 @@ from langfuse import observe
 from openai import OpenAI
 from pydantic import BaseModel
 
-from src.agents.auditor import SubAgentFinding, SubAgentReport
+from src.schemas import SubAgentFinding, SubAgentReport
 
 
 class _FindingsList(BaseModel):

--- a/src/detectors/llm_tonal.py
+++ b/src/detectors/llm_tonal.py
@@ -5,7 +5,7 @@ from langfuse import observe
 from openai import OpenAI
 from pydantic import BaseModel
 
-from src.agents.auditor import SubAgentFinding, SubAgentReport
+from src.schemas import SubAgentFinding, SubAgentReport
 
 
 class _FindingsList(BaseModel):

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,0 +1,15 @@
+from .lexical import SentenceHit, LexicalSummary, LexicalWordReport
+from .audit import SubAgentFinding, SubAgentReport, FlaggedSentence, AuditReport
+from .rewrite import RewriteResult, RewriteReport
+
+__all__ = [
+    "SentenceHit",
+    "LexicalSummary",
+    "LexicalWordReport",
+    "SubAgentFinding",
+    "SubAgentReport",
+    "FlaggedSentence",
+    "AuditReport",
+    "RewriteResult",
+    "RewriteReport",
+]

--- a/src/schemas/audit.py
+++ b/src/schemas/audit.py
@@ -1,0 +1,38 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+from .lexical import LexicalSummary
+
+
+class SubAgentFinding(BaseModel):
+    sentence_id: str
+    text: str
+    patterns_found: list[str]
+    severity: Literal["low", "medium", "high"]
+    suggested_fix: str
+
+
+class SubAgentReport(BaseModel):
+    category: Literal["lexical", "structural", "tonal", "rhythmic"]
+    findings: list[SubAgentFinding]
+
+
+class FlaggedSentence(BaseModel):
+    sentence_id: str
+    text: str
+    labels: dict[str, list[str]]     # {category: [pattern names]}
+    suggested_fixes: dict[str, str]  # {category: suggested fix}
+    severity: Literal["low", "medium", "high"]
+    is_flagged: bool
+
+
+class AuditReport(BaseModel):
+    article_id: str
+    model: str
+    verdict: Literal["patch", "structural_rewrite_needed"]
+    flag_count: int
+    category_count: int
+    lexical_summary: LexicalSummary
+    sub_reports: dict[str, SubAgentReport]
+    flagged_sentences: list[FlaggedSentence]

--- a/src/schemas/lexical.py
+++ b/src/schemas/lexical.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class SentenceHit(BaseModel):
+    sentence_id: str
+    text: str
+    matched_words: list[str]
+    tier: int  # 1, 2, or 3
+
+
+class LexicalSummary(BaseModel):
+    tier_1_hits: list[str]            # all tier-1 words found (article-level)
+    tier_2_clusters: list[list[str]]  # paragraph-level clusters
+    tier_3_density: float             # ratio: tier-3 words / total words
+
+
+class LexicalWordReport(BaseModel):
+    lexical_summary: LexicalSummary
+    sentence_hits: list[SentenceHit]

--- a/src/schemas/rewrite.py
+++ b/src/schemas/rewrite.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class RewriteResult(BaseModel):
+    sentence_id: str
+    original: str
+    rewritten: str
+    change_summary: str
+
+
+class RewriteReport(BaseModel):
+    article_id: str
+    model: str
+    rewrites: list[RewriteResult]
+    full_rewritten_text: str

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -66,12 +66,20 @@ def test_import_detectors_llm_rhythmic():
     assert LLMRhythmicAgent is not None
 
 
-def test_import_new_auditor_schemas():
-    from src.agents.auditor import (
+def test_import_schemas_package():
+    from src.schemas import (
         SentenceHit,
         LexicalSummary,
         LexicalWordReport,
         SubAgentFinding,
         SubAgentReport,
+        FlaggedSentence,
+        AuditReport,
+        RewriteResult,
+        RewriteReport,
     )
-    assert all([SentenceHit, LexicalSummary, LexicalWordReport, SubAgentFinding, SubAgentReport])
+    assert all([
+        SentenceHit, LexicalSummary, LexicalWordReport,
+        SubAgentFinding, SubAgentReport, FlaggedSentence,
+        AuditReport, RewriteResult, RewriteReport,
+    ])

--- a/tests/test_llm_agents.py
+++ b/tests/test_llm_agents.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from src.agents.auditor import SubAgentFinding, SubAgentReport
+from src.schemas import SubAgentFinding, SubAgentReport
 
 
 def test_llm_lexical_agent_returns_sub_agent_report():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,5 +1,5 @@
 def test_flagged_sentence_schema():
-    from src.agents.auditor import FlaggedSentence
+    from src.schemas import FlaggedSentence
     s = FlaggedSentence(
         sentence_id="test_001_s01",
         text="Delve into the nuanced landscape.",
@@ -13,7 +13,7 @@ def test_flagged_sentence_schema():
 
 
 def test_audit_report_schema():
-    from src.agents.auditor import AuditReport, LexicalSummary
+    from src.schemas import AuditReport, LexicalSummary
     report = AuditReport(
         article_id="test_001",
         model="mistral",
@@ -33,7 +33,7 @@ def test_audit_report_schema():
 
 
 def test_sub_agent_report_schema():
-    from src.agents.auditor import SubAgentReport, SubAgentFinding
+    from src.schemas import SubAgentReport, SubAgentFinding
     report = SubAgentReport(
         category="lexical",
         findings=[
@@ -51,7 +51,7 @@ def test_sub_agent_report_schema():
 
 
 def test_lexical_word_report_schema():
-    from src.agents.auditor import LexicalWordReport, LexicalSummary, SentenceHit
+    from src.schemas import LexicalWordReport, LexicalSummary, SentenceHit
     report = LexicalWordReport(
         lexical_summary=LexicalSummary(
             tier_1_hits=["delve"],
@@ -72,7 +72,7 @@ def test_lexical_word_report_schema():
 
 
 def test_rewrite_result_schema():
-    from src.agents.rewriter import RewriteResult
+    from src.schemas import RewriteResult
     r = RewriteResult(
         sentence_id="test_001_s01",
         original="Delve into the nuanced landscape.",
@@ -83,7 +83,7 @@ def test_rewrite_result_schema():
 
 
 def test_rewrite_report_schema():
-    from src.agents.rewriter import RewriteReport
+    from src.schemas import RewriteReport
     report = RewriteReport(
         article_id="test_001",
         model="mistral",


### PR DESCRIPTION
## Summary
- Moved 9 Pydantic v2 schema classes out of `src/agents/auditor.py` and `src/agents/rewriter.py` into a new `src/schemas/` package
- Updated all callers (5 detector files, both agent files, 3 test files) to import from `src.schemas`
- Agents and detectors are now callers only — no schema definitions outside `src/schemas/`

## Test Plan
- [x] 44/44 tests pass on `feat/schema-extraction`
- [x] All schema classes accessible via `from src.schemas import ...`
- [x] No duplicate class definitions remain in agent files