### PR TITLE
feat: implement Rewriter + wire CLI and Streamlit UI (two-pass pipeline)

### DIFF
--- a/review.py
+++ b/review.py
@@ -1,13 +1,52 @@
+import hashlib
 from pathlib import Path
 from typing import Optional
 
 import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.rule import Rule
+from rich.text import Text
 
 app = typer.Typer(
     name="review",
     help="Local AI Writing Auditor — detect and rewrite AI writing tells using local Ollama models.",
     add_completion=False,
 )
+console = Console()
+
+
+def _article_id(file: Path) -> str:
+    """Stable short ID derived from filename."""
+    return hashlib.md5(file.name.encode()).hexdigest()[:8]
+
+
+def _print_issues(flagged_sentences) -> None:
+    if not flagged_sentences:
+        console.print("[green]No AI writing tells detected.[/green]")
+        return
+    for fs in flagged_sentences:
+        active = {k: v for k, v in fs.labels.items() if v}
+        label_str = "  ".join(
+            f"[yellow]{cat}[/yellow]: {', '.join(patterns)}"
+            for cat, patterns in active.items()
+        )
+        severity_color = {"high": "red", "medium": "yellow", "low": "cyan"}.get(fs.severity, "white")
+        console.print(
+            Panel(
+                f"[italic]{fs.text}[/italic]\n{label_str}",
+                title=f"[{severity_color}]{fs.severity.upper()}[/{severity_color}]  {fs.sentence_id}",
+                border_style=severity_color,
+            )
+        )
+
+
+def _print_what_changed(rewrites) -> None:
+    if not rewrites:
+        console.print("[dim]Nothing rewritten.[/dim]")
+        return
+    for r in rewrites:
+        console.print(f"  [dim]{r.sentence_id}[/dim]  {r.change_summary}")
 
 
 @app.command()
@@ -22,13 +61,67 @@ def review(
     output_json: Optional[Path] = typer.Option(None, "--output-json", help="Write full audit report to JSON file"),
 ) -> None:
     """Audit an article for AI writing tells and optionally rewrite them."""
-    raise NotImplementedError(
-        f"Pipeline not implemented yet.\n"
-        f"  file={file}\n"
-        f"  model={model}\n"
-        f"  mode={mode}\n"
-        f"  output_json={output_json}"
+    from src.agents.auditor import AuditorAgent
+    from src.agents.rewriter import RewriterAgent
+
+    text = file.read_text(encoding="utf-8")
+    article_id = _article_id(file)
+
+    console.print(Rule(f"[bold]AI Writing Auditor[/bold]  model={model}  mode={mode}"))
+
+    # --- Pass 1: Audit ---
+    console.print("\n[bold cyan]Running Pass 1 audit…[/bold cyan]")
+    auditor = AuditorAgent(model=model)
+    audit_report = auditor.run(text=text, article_id=article_id)
+
+    console.print(Rule("[bold]Issues Found[/bold]"))
+    console.print(f"Verdict: [bold]{audit_report.verdict}[/bold]  |  {audit_report.flag_count} flags  |  {audit_report.category_count} categories\n")
+    _print_issues(audit_report.flagged_sentences)
+
+    if mode == "detect-only":
+        if output_json:
+            output_json.write_text(audit_report.model_dump_json(indent=2), encoding="utf-8")
+            console.print(f"\n[dim]Report written to {output_json}[/dim]")
+        console.print(Rule("[dim]detect-only mode — skipping rewrite[/dim]"))
+        return
+
+    # --- Rewrite ---
+    console.print(f"\n[bold cyan]Rewriting {len(audit_report.flagged_sentences)} flagged sentences…[/bold cyan]")
+    rewriter = RewriterAgent(model=model)
+    rewrite_report = rewriter.run(
+        flagged_sentences=audit_report.flagged_sentences,
+        article_id=article_id,
+        original_text=text,
     )
+
+    console.print(Rule("[bold]Rewritten Version[/bold]"))
+    console.print(rewrite_report.full_rewritten_text)
+
+    console.print(Rule("[bold]What Changed[/bold]"))
+    _print_what_changed(rewrite_report.rewrites)
+
+    # --- Pass 2: Re-audit rewritten text ---
+    console.print("\n[bold cyan]Running Pass 2 audit on rewritten text…[/bold cyan]")
+    pass2_report = auditor.run(text=rewrite_report.full_rewritten_text, article_id=f"{article_id}_pass2")
+
+    console.print(Rule("[bold]Second-Pass Audit[/bold]"))
+    if not pass2_report.flagged_sentences:
+        console.print("[green]No surviving patterns detected. Rewrite is clean.[/green]")
+    else:
+        console.print(f"[yellow]{pass2_report.flag_count} pattern(s) survived the rewrite:[/yellow]\n")
+        _print_issues(pass2_report.flagged_sentences)
+
+    if output_json:
+        import json
+        combined = {
+            "pass1": audit_report.model_dump(),
+            "rewrite": rewrite_report.model_dump(),
+            "pass2": pass2_report.model_dump(),
+        }
+        output_json.write_text(json.dumps(combined, indent=2), encoding="utf-8")
+        console.print(f"\n[dim]Report written to {output_json}[/dim]")
+
+    console.print(Rule())
 
 
 if __name__ == "__main__":

--- a/review.py
+++ b/review.py
@@ -1,3 +1,4 @@
+import enum
 import hashlib
 from pathlib import Path
 from typing import Optional
@@ -6,7 +7,11 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
-from rich.text import Text
+
+class Mode(str, enum.Enum):
+    rewrite = "rewrite"
+    detect_only = "detect-only"
+
 
 app = typer.Typer(
     name="review",
@@ -53,8 +58,8 @@ def _print_what_changed(rewrites) -> None:
 def review(
     file: Path = typer.Option(..., "--file", help="Path to article file (.md or .txt)", exists=True),
     model: str = typer.Option("mistral", "--model", help="Ollama model tag: mistral | llama3.2:3b | phi4"),
-    mode: str = typer.Option(
-        "rewrite",
+    mode: Mode = typer.Option(
+        Mode.rewrite,
         "--mode",
         help="Pipeline mode: 'rewrite' (detect + rewrite, two-pass) or 'detect-only' (audit report only)",
     ),
@@ -78,7 +83,7 @@ def review(
     console.print(f"Verdict: [bold]{audit_report.verdict}[/bold]  |  {audit_report.flag_count} flags  |  {audit_report.category_count} categories\n")
     _print_issues(audit_report.flagged_sentences)
 
-    if mode == "detect-only":
+    if mode == Mode.detect_only:
         if output_json:
             output_json.write_text(audit_report.model_dump_json(indent=2), encoding="utf-8")
             console.print(f"\n[dim]Report written to {output_json}[/dim]")

--- a/src/agents/rewriter.py
+++ b/src/agents/rewriter.py
@@ -1,5 +1,6 @@
 import instructor
 from langfuse import observe
+from loguru import logger
 from openai import OpenAI
 from pydantic import BaseModel
 
@@ -36,11 +37,11 @@ class RewriterAgent:
 
     def __init__(self, model: str) -> None:
         self.model = model
-
-    def _call_llm(self, sentence: FlaggedSentence) -> RewriteResult:
-        client = instructor.from_openai(
+        self.client = instructor.from_openai(
             OpenAI(base_url="http://localhost:11434/v1", api_key="ollama")
         )
+
+    def _call_llm(self, sentence: FlaggedSentence) -> RewriteResult:
         active_labels = {k: v for k, v in sentence.labels.items() if v}
         suggested_fix = " | ".join(
             f"{cat}: {fix}" for cat, fix in sentence.suggested_fixes.items()
@@ -52,7 +53,7 @@ class RewriterAgent:
             suggested_fix=suggested_fix,
             sentence_id=sentence.sentence_id,
         )
-        wrapper = client.chat.completions.create(
+        wrapper = self.client.chat.completions.create(
             model=self.model,
             response_model=_RewriteResultWrapper,
             messages=[{"role": "user", "content": prompt}],
@@ -92,6 +93,14 @@ class RewriterAgent:
         rewritten_text = original_text
         for rewrite in rewrites:
             rewritten_text = rewritten_text.replace(rewrite.original, rewrite.rewritten, 1)
+
+        for rewrite in rewrites:
+            if rewrite.original not in original_text:
+                logger.warning(
+                    "Rewrite original not found in text — substitution skipped: sentence_id={} original={!r}",
+                    rewrite.sentence_id,
+                    rewrite.original,
+                )
 
         return RewriteReport(
             article_id=article_id,

--- a/src/agents/rewriter.py
+++ b/src/agents/rewriter.py
@@ -1,6 +1,34 @@
+import instructor
 from langfuse import observe
+from openai import OpenAI
+from pydantic import BaseModel
 
-from src.schemas import FlaggedSentence, RewriteResult, RewriteReport
+from src.schemas import FlaggedSentence, RewriteReport, RewriteResult
+
+_PROMPT = """\
+You are a writing editor. Rewrite the following sentence to remove AI writing tells \
+while preserving the author's intent, voice, and meaning.
+
+Original sentence: {sentence}
+Tell categories detected: {labels}
+Suggested fix hint: {suggested_fix}
+
+Rules:
+- Only fix the specific tells identified — do not rewrite unrelated parts
+- Preserve the author's voice and approximate sentence length
+- Do not add new phrases; replace or remove existing ones
+- If the suggested fix is good, use it as a starting point
+
+Return a RewriteResult with:
+- sentence_id: {sentence_id}
+- original: the original sentence (copy it exactly)
+- rewritten: your rewritten version
+- change_summary: one plain-language sentence explaining what changed and why
+"""
+
+
+class _RewriteResultWrapper(BaseModel):
+    result: RewriteResult
 
 
 class RewriterAgent:
@@ -9,15 +37,65 @@ class RewriterAgent:
     def __init__(self, model: str) -> None:
         self.model = model
 
+    def _call_llm(self, sentence: FlaggedSentence) -> RewriteResult:
+        client = instructor.from_openai(
+            OpenAI(base_url="http://localhost:11434/v1", api_key="ollama")
+        )
+        active_labels = {k: v for k, v in sentence.labels.items() if v}
+        suggested_fix = " | ".join(
+            f"{cat}: {fix}" for cat, fix in sentence.suggested_fixes.items()
+        ) or "none"
+
+        prompt = _PROMPT.format(
+            sentence=sentence.text,
+            labels=active_labels,
+            suggested_fix=suggested_fix,
+            sentence_id=sentence.sentence_id,
+        )
+        wrapper = client.chat.completions.create(
+            model=self.model,
+            response_model=_RewriteResultWrapper,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return wrapper.result
+
     @observe()
-    def run(self, flagged_sentences: list[FlaggedSentence], article_id: str) -> RewriteReport:
+    def run(
+        self,
+        flagged_sentences: list[FlaggedSentence],
+        article_id: str,
+        original_text: str,
+    ) -> RewriteReport:
         """Rewrite each flagged sentence. Returns full rewrite report.
 
         Args:
             flagged_sentences: Sentences flagged by AuditorAgent.
             article_id: Article identifier, carried through to output.
+            original_text: Full original article text (used to build full_rewritten_text).
 
         Returns:
             RewriteReport with per-sentence rewrites and full rewritten article text.
         """
-        raise NotImplementedError
+        if not flagged_sentences:
+            return RewriteReport(
+                article_id=article_id,
+                model=self.model,
+                rewrites=[],
+                full_rewritten_text=original_text,
+            )
+
+        rewrites: list[RewriteResult] = []
+        for sentence in flagged_sentences:
+            rewrite = self._call_llm(sentence)
+            rewrites.append(rewrite)
+
+        rewritten_text = original_text
+        for rewrite in rewrites:
+            rewritten_text = rewritten_text.replace(rewrite.original, rewrite.rewritten, 1)
+
+        return RewriteReport(
+            article_id=article_id,
+            model=self.model,
+            rewrites=rewrites,
+            full_rewritten_text=rewritten_text,
+        )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,4 +1,32 @@
+import hashlib
+
 import streamlit as st
+
+
+def _article_id(text: str) -> str:
+    return hashlib.md5(text.encode()).hexdigest()[:8]
+
+
+def _severity_color(severity: str) -> str:
+    return {"high": "#ff4b4b", "medium": "#ffa500", "low": "#1f77b4"}.get(severity, "#888")
+
+
+def _render_flagged_sentences(flagged_sentences) -> None:
+    if not flagged_sentences:
+        st.success("No AI writing tells detected.")
+        return
+    for fs in flagged_sentences:
+        active = {k: v for k, v in fs.labels.items() if v}
+        label_parts = [f"**{cat}**: {', '.join(patterns)}" for cat, patterns in active.items()]
+        color = _severity_color(fs.severity)
+        st.markdown(
+            f'<div style="border-left: 4px solid {color}; padding: 8px 12px; margin-bottom: 8px;">'
+            f"<small style='color:{color}'>{fs.severity.upper()} · {fs.sentence_id}</small><br>"
+            f"<em>{fs.text}</em><br>"
+            f"<small>{' &nbsp;|&nbsp; '.join(label_parts)}</small>"
+            "</div>",
+            unsafe_allow_html=True,
+        )
 
 
 def main() -> None:
@@ -11,7 +39,7 @@ def main() -> None:
         model = st.selectbox("Model", ["mistral", "llama3.2:3b", "phi4"])
         mode = st.radio("Mode", ["rewrite", "detect-only"])
         st.divider()
-        st.caption("Token stats will appear here during inference.")
+        st.caption("Traces visible in Langfuse after each run.")
 
     # --- Main panels ---
     col_left, col_right = st.columns(2)
@@ -23,22 +51,73 @@ def main() -> None:
 
     with col_right:
         st.subheader("Flagged Sentences")
-        st.info("Flagged sentences with tell category labels will appear here after analysis.")
+        flagged_placeholder = st.empty()
+        flagged_placeholder.info("Flagged sentences will appear here after analysis.")
 
-    # --- Rewrite panel ---
+    # --- Run pipeline ---
+    if run and not text:
+        st.warning("Please paste article text before running analysis.")
+        return
+
     if run and text:
+        from src.agents.auditor import AuditorAgent
+        from src.agents.rewriter import RewriterAgent
+
+        article_id = _article_id(text)
+
+        with st.spinner("Pass 1: Auditing…"):
+            auditor = AuditorAgent(model=model)
+            audit_report = auditor.run(text=text, article_id=article_id)
+
+        with col_right:
+            flagged_placeholder.empty()
+            st.subheader("Flagged Sentences")
+            st.caption(
+                f"Verdict: **{audit_report.verdict}** · {audit_report.flag_count} flags · {audit_report.category_count} categories"
+            )
+            _render_flagged_sentences(audit_report.flagged_sentences)
+
+        if mode == "detect-only":
+            st.divider()
+            st.caption("detect-only mode — rewrite skipped.")
+            return
+
+        # --- Rewrite ---
         st.divider()
+        with st.spinner(f"Rewriting {len(audit_report.flagged_sentences)} flagged sentences…"):
+            rewriter = RewriterAgent(model=model)
+            rewrite_report = rewriter.run(
+                flagged_sentences=audit_report.flagged_sentences,
+                article_id=article_id,
+                original_text=text,
+            )
+
         st.subheader("Rewritten Version")
-        st.info("Rewritten article text will appear here.")
+        st.text_area(
+            label="Rewritten article",
+            value=rewrite_report.full_rewritten_text,
+            height=300,
+            label_visibility="collapsed",
+        )
+
+        if rewrite_report.rewrites:
+            with st.expander("What Changed"):
+                for r in rewrite_report.rewrites:
+                    st.markdown(f"- **{r.sentence_id}**: {r.change_summary}")
+
+        # --- Pass 2 ---
+        with st.spinner("Pass 2: Re-auditing rewritten text…"):
+            pass2_report = auditor.run(
+                text=rewrite_report.full_rewritten_text,
+                article_id=f"{article_id}_pass2",
+            )
 
         with st.expander("Second-Pass Audit"):
-            st.info("Patterns that survived the first rewrite will be listed here.")
-
-    elif run and not text:
-        st.warning("Please paste article text before running analysis.")
-
-    # Suppress unused variable warnings — wired in implementation phase
-    _ = model, mode
+            if not pass2_report.flagged_sentences:
+                st.success("No surviving patterns. Rewrite is clean.")
+            else:
+                st.warning(f"{pass2_report.flag_count} pattern(s) survived the rewrite:")
+                _render_flagged_sentences(pass2_report.flagged_sentences)
 
 
 if __name__ == "__main__":

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -71,7 +71,6 @@ def main() -> None:
 
         with col_right:
             flagged_placeholder.empty()
-            st.subheader("Flagged Sentences")
             st.caption(
                 f"Verdict: **{audit_report.verdict}** · {audit_report.flag_count} flags · {audit_report.category_count} categories"
             )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -4,6 +4,7 @@ import streamlit as st
 
 
 def _article_id(text: str) -> str:
+    """Stable short ID derived from content (no filename available in UI context)."""
     return hashlib.md5(text.encode()).hexdigest()[:8]
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -83,3 +83,8 @@ def test_import_schemas_package():
         SubAgentFinding, SubAgentReport, FlaggedSentence,
         AuditReport, RewriteResult, RewriteReport,
     ])
+
+
+def test_import_review_cli():
+    from review import review as review_cmd
+    assert callable(review_cmd)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -88,3 +88,8 @@ def test_import_schemas_package():
 def test_import_review_cli():
     from review import review as review_cmd
     assert callable(review_cmd)
+
+
+def test_import_ui_app():
+    from src.ui.app import main
+    assert callable(main)

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+
+from src.schemas import FlaggedSentence, RewriteReport, RewriteResult
+
+
+def _make_flagged(sid: str, text: str) -> FlaggedSentence:
+    return FlaggedSentence(
+        sentence_id=sid,
+        text=text,
+        labels={"lexical": ["delve"], "structural": [], "tonal": [], "rhythmic": []},
+        severity="high",
+        is_flagged=True,
+        suggested_fixes={"lexical": "Explore the complex field."},
+    )
+
+
+def test_rewriter_returns_rewrite_report():
+    from src.agents.rewriter import RewriterAgent
+
+    agent = RewriterAgent(model="mistral")
+    flagged = [_make_flagged("art_001_s000", "Delve into the complex field.")]
+    original_text = "Delve into the complex field. It covers many topics."
+
+    mock_result = RewriteResult(
+        sentence_id="art_001_s000",
+        original="Delve into the complex field.",
+        rewritten="Explore the complex field.",
+        change_summary="Replaced 'delve' with 'explore'.",
+    )
+
+    with patch.object(agent, "_call_llm", return_value=mock_result):
+        result = agent.run(flagged, "art_001", original_text)
+
+    assert isinstance(result, RewriteReport)
+    assert result.article_id == "art_001"
+    assert result.model == "mistral"
+    assert len(result.rewrites) == 1
+    assert result.rewrites[0].rewritten == "Explore the complex field."
+    assert "Explore the complex field." in result.full_rewritten_text
+    assert "Delve into the complex field." not in result.full_rewritten_text
+
+
+def test_rewriter_returns_empty_report_for_no_flags():
+    from src.agents.rewriter import RewriterAgent
+
+    agent = RewriterAgent(model="mistral")
+    original_text = "The build passed. No issues found."
+
+    result = agent.run([], "art_001", original_text)
+
+    assert isinstance(result, RewriteReport)
+    assert result.rewrites == []
+    assert result.full_rewritten_text == original_text
+
+
+def test_rewriter_substitutes_multiple_sentences():
+    from src.agents.rewriter import RewriterAgent
+
+    agent = RewriterAgent(model="mistral")
+    flagged = [
+        _make_flagged("art_001_s000", "Delve into this."),
+        _make_flagged("art_001_s001", "Leverage these tools."),
+    ]
+    original_text = "Delve into this. Leverage these tools. The end."
+
+    mock_results = [
+        RewriteResult(
+            sentence_id="art_001_s000",
+            original="Delve into this.",
+            rewritten="Explore this.",
+            change_summary="Replaced 'delve'.",
+        ),
+        RewriteResult(
+            sentence_id="art_001_s001",
+            original="Leverage these tools.",
+            rewritten="Use these tools.",
+            change_summary="Replaced 'leverage'.",
+        ),
+    ]
+
+    with patch.object(agent, "_call_llm", side_effect=mock_results):
+        result = agent.run(flagged, "art_001", original_text)
+
+    assert len(result.rewrites) == 2
+    assert "Explore this." in result.full_rewritten_text
+    assert "Use these tools." in result.full_rewritten_text
+    assert "Delve" not in result.full_rewritten_text
+    assert "Leverage" not in result.full_rewritten_text

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -84,5 +84,5 @@ def test_rewriter_substitutes_multiple_sentences():
     assert len(result.rewrites) == 2
     assert "Explore this." in result.full_rewritten_text
     assert "Use these tools." in result.full_rewritten_text
-    assert "Delve" not in result.full_rewritten_text
-    assert "Leverage" not in result.full_rewritten_text
+    assert "Delve into this." not in result.full_rewritten_text
+    assert "Leverage these tools." not in result.full_rewritten_text


### PR DESCRIPTION
Closes #3

## Summary

- **RewriterAgent** (`src/agents/rewriter.py`): rewrites flagged sentences one-by-one via `instructor`-enforced structured output; `@observe()` traced; client instantiated once in `__init__`; logs a warning when an LLM-returned `original` can't be found in the source text
- **CLI** (`review.py`): full Rich-formatted four-section report (Pass 1 issues → rewritten version → what changed → Pass 2 audit); `Mode` enum validates `--mode` at the CLI layer; `--output-json` writes combined JSON
- **Streamlit UI** (`src/ui/app.py`): two-column layout with sidebar model/mode controls; Pass 1 flagged sentences rendered as severity-coloured cards; rewritten text in editable area; "What Changed" and "Second-Pass Audit" expanders; `detect-only` mode skips rewrite

## Test plan

- [x] `uv run pytest -v` → 49 tests pass (44 existing + 3 rewriter + 2 smoke tests)
- [ ] CLI detect-only: `uv run python review.py --file <article> --mode detect-only`
- [ ] CLI full pipeline: `uv run python review.py --file <article> --model mistral`
- [ ] Streamlit UI: `uv run streamlit run src/ui/app.py`
- [ ] Invalid `--mode` value rejected at CLI (Typer enum validation)