### PR TITLE
refactor: extract pipeline orchestration into src/pipeline.py

### DIFF
--- a/review.py
+++ b/review.py
@@ -1,5 +1,5 @@
+import json
 import enum
-import hashlib
 from pathlib import Path
 from typing import Optional
 
@@ -7,6 +7,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
+
 
 class Mode(str, enum.Enum):
     rewrite = "rewrite"
@@ -19,11 +20,6 @@ app = typer.Typer(
     add_completion=False,
 )
 console = Console()
-
-
-def _article_id(file: Path) -> str:
-    """Stable short ID derived from filename."""
-    return hashlib.md5(file.name.encode()).hexdigest()[:8]
 
 
 def _print_issues(flagged_sentences) -> None:
@@ -66,62 +62,59 @@ def review(
     output_json: Optional[Path] = typer.Option(None, "--output-json", help="Write full audit report to JSON file"),
 ) -> None:
     """Audit an article for AI writing tells and optionally rewrite them."""
-    from src.agents.auditor import AuditorAgent
-    from src.agents.rewriter import RewriterAgent
+    from src.pipeline import run_detect_only, run_full_pipeline
 
     text = file.read_text(encoding="utf-8")
-    article_id = _article_id(file)
 
     console.print(Rule(f"[bold]AI Writing Auditor[/bold]  model={model}  mode={mode}"))
 
-    # --- Pass 1: Audit ---
-    console.print("\n[bold cyan]Running Pass 1 audit…[/bold cyan]")
-    auditor = AuditorAgent(model=model)
-    audit_report = auditor.run(text=text, article_id=article_id)
-
-    console.print(Rule("[bold]Issues Found[/bold]"))
-    console.print(f"Verdict: [bold]{audit_report.verdict}[/bold]  |  {audit_report.flag_count} flags  |  {audit_report.category_count} categories\n")
-    _print_issues(audit_report.flagged_sentences)
-
     if mode == Mode.detect_only:
+        console.print("\n[bold cyan]Running Pass 1 audit…[/bold cyan]")
+        result = run_detect_only(text=text, model=model)
+
+        console.print(Rule("[bold]Issues Found[/bold]"))
+        console.print(
+            f"Verdict: [bold]{result.pass1.verdict}[/bold]  |  "
+            f"{result.pass1.flag_count} flags  |  {result.pass1.category_count} categories\n"
+        )
+        _print_issues(result.pass1.flagged_sentences)
+
         if output_json:
-            output_json.write_text(audit_report.model_dump_json(indent=2), encoding="utf-8")
+            output_json.write_text(result.pass1.model_dump_json(indent=2), encoding="utf-8")
             console.print(f"\n[dim]Report written to {output_json}[/dim]")
+
         console.print(Rule("[dim]detect-only mode — skipping rewrite[/dim]"))
         return
 
-    # --- Rewrite ---
-    console.print(f"\n[bold cyan]Rewriting {len(audit_report.flagged_sentences)} flagged sentences…[/bold cyan]")
-    rewriter = RewriterAgent(model=model)
-    rewrite_report = rewriter.run(
-        flagged_sentences=audit_report.flagged_sentences,
-        article_id=article_id,
-        original_text=text,
+    # Full pipeline
+    console.print("\n[bold cyan]Running Pass 1 audit…[/bold cyan]")
+    result = run_full_pipeline(text=text, model=model)
+
+    console.print(Rule("[bold]Issues Found[/bold]"))
+    console.print(
+        f"Verdict: [bold]{result.pass1.verdict}[/bold]  |  "
+        f"{result.pass1.flag_count} flags  |  {result.pass1.category_count} categories\n"
     )
+    _print_issues(result.pass1.flagged_sentences)
 
     console.print(Rule("[bold]Rewritten Version[/bold]"))
-    console.print(rewrite_report.full_rewritten_text)
+    console.print(result.rewrite.full_rewritten_text)
 
     console.print(Rule("[bold]What Changed[/bold]"))
-    _print_what_changed(rewrite_report.rewrites)
-
-    # --- Pass 2: Re-audit rewritten text ---
-    console.print("\n[bold cyan]Running Pass 2 audit on rewritten text…[/bold cyan]")
-    pass2_report = auditor.run(text=rewrite_report.full_rewritten_text, article_id=f"{article_id}_pass2")
+    _print_what_changed(result.rewrite.rewrites)
 
     console.print(Rule("[bold]Second-Pass Audit[/bold]"))
-    if not pass2_report.flagged_sentences:
+    if not result.pass2.flagged_sentences:
         console.print("[green]No surviving patterns detected. Rewrite is clean.[/green]")
     else:
-        console.print(f"[yellow]{pass2_report.flag_count} pattern(s) survived the rewrite:[/yellow]\n")
-        _print_issues(pass2_report.flagged_sentences)
+        console.print(f"[yellow]{result.pass2.flag_count} pattern(s) survived the rewrite:[/yellow]\n")
+        _print_issues(result.pass2.flagged_sentences)
 
     if output_json:
-        import json
         combined = {
-            "pass1": audit_report.model_dump(),
-            "rewrite": rewrite_report.model_dump(),
-            "pass2": pass2_report.model_dump(),
+            "pass1": result.pass1.model_dump(),
+            "rewrite": result.rewrite.model_dump(),
+            "pass2": result.pass2.model_dump(),
         }
         output_json.write_text(json.dumps(combined, indent=2), encoding="utf-8")
         console.print(f"\n[dim]Report written to {output_json}[/dim]")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,44 @@
+# src/pipeline.py
+import hashlib
+from dataclasses import dataclass
+
+from src.agents.auditor import AuditorAgent
+from src.agents.rewriter import RewriterAgent
+from src.schemas.audit import AuditReport
+from src.schemas.rewrite import RewriteReport
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    article_id: str
+    pass1: AuditReport
+    rewrite: RewriteReport | None
+    pass2: AuditReport | None
+
+
+def _article_id(text: str) -> str:
+    return hashlib.md5(text.encode()).hexdigest()[:8]
+
+
+def run_detect_only(text: str, model: str) -> PipelineResult:
+    article_id = _article_id(text)
+    auditor = AuditorAgent(model=model)
+    pass1 = auditor.run(text=text, article_id=article_id)
+    return PipelineResult(article_id=article_id, pass1=pass1, rewrite=None, pass2=None)
+
+
+def run_full_pipeline(text: str, model: str) -> PipelineResult:
+    article_id = _article_id(text)
+    auditor = AuditorAgent(model=model)
+    rewriter = RewriterAgent(model=model)
+    pass1 = auditor.run(text=text, article_id=article_id)
+    rewrite = rewriter.run(
+        flagged_sentences=pass1.flagged_sentences,
+        article_id=article_id,
+        original_text=text,
+    )
+    pass2 = auditor.run(
+        text=rewrite.full_rewritten_text,
+        article_id=f"{article_id}_pass2",
+    )
+    return PipelineResult(article_id=article_id, pass1=pass1, rewrite=rewrite, pass2=pass2)

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,11 +1,4 @@
-import hashlib
-
 import streamlit as st
-
-
-def _article_id(text: str) -> str:
-    """Stable short ID derived from content (no filename available in UI context)."""
-    return hashlib.md5(text.encode()).hexdigest()[:8]
 
 
 def _severity_color(severity: str) -> str:
@@ -34,7 +27,6 @@ def main() -> None:
     st.set_page_config(page_title="AI Writing Auditor", layout="wide")
     st.title("Local AI Writing Auditor")
 
-    # --- Sidebar ---
     with st.sidebar:
         st.header("Settings")
         model = st.selectbox("Model", ["mistral", "llama3.2:3b", "phi4"])
@@ -42,7 +34,6 @@ def main() -> None:
         st.divider()
         st.caption("Traces visible in Langfuse after each run.")
 
-    # --- Main panels ---
     col_left, col_right = st.columns(2)
 
     with col_left:
@@ -55,69 +46,60 @@ def main() -> None:
         flagged_placeholder = st.empty()
         flagged_placeholder.info("Flagged sentences will appear here after analysis.")
 
-    # --- Run pipeline ---
     if run and not text:
         st.warning("Please paste article text before running analysis.")
         return
 
     if run and text:
-        from src.agents.auditor import AuditorAgent
-        from src.agents.rewriter import RewriterAgent
-
-        article_id = _article_id(text)
-
-        with st.spinner("Pass 1: Auditing…"):
-            auditor = AuditorAgent(model=model)
-            audit_report = auditor.run(text=text, article_id=article_id)
-
-        with col_right:
-            flagged_placeholder.empty()
-            st.caption(
-                f"Verdict: **{audit_report.verdict}** · {audit_report.flag_count} flags · {audit_report.category_count} categories"
-            )
-            _render_flagged_sentences(audit_report.flagged_sentences)
+        from src.pipeline import run_detect_only, run_full_pipeline
 
         if mode == "detect-only":
+            with st.spinner("Pass 1: Auditing…"):
+                result = run_detect_only(text=text, model=model)
+
+            with col_right:
+                flagged_placeholder.empty()
+                st.caption(
+                    f"Verdict: **{result.pass1.verdict}** · "
+                    f"{result.pass1.flag_count} flags · {result.pass1.category_count} categories"
+                )
+                _render_flagged_sentences(result.pass1.flagged_sentences)
+
             st.divider()
             st.caption("detect-only mode — rewrite skipped.")
             return
 
-        # --- Rewrite ---
-        st.divider()
-        with st.spinner(f"Rewriting {len(audit_report.flagged_sentences)} flagged sentences…"):
-            rewriter = RewriterAgent(model=model)
-            rewrite_report = rewriter.run(
-                flagged_sentences=audit_report.flagged_sentences,
-                article_id=article_id,
-                original_text=text,
-            )
+        with st.spinner("Running full pipeline (pass 1 → rewrite → pass 2)…"):
+            result = run_full_pipeline(text=text, model=model)
 
+        with col_right:
+            flagged_placeholder.empty()
+            st.caption(
+                f"Verdict: **{result.pass1.verdict}** · "
+                f"{result.pass1.flag_count} flags · {result.pass1.category_count} categories"
+            )
+            _render_flagged_sentences(result.pass1.flagged_sentences)
+
+        st.divider()
         st.subheader("Rewritten Version")
         st.text_area(
             label="Rewritten article",
-            value=rewrite_report.full_rewritten_text,
+            value=result.rewrite.full_rewritten_text,
             height=300,
             label_visibility="collapsed",
         )
 
-        if rewrite_report.rewrites:
+        if result.rewrite.rewrites:
             with st.expander("What Changed"):
-                for r in rewrite_report.rewrites:
+                for r in result.rewrite.rewrites:
                     st.markdown(f"- **{r.sentence_id}**: {r.change_summary}")
 
-        # --- Pass 2 ---
-        with st.spinner("Pass 2: Re-auditing rewritten text…"):
-            pass2_report = auditor.run(
-                text=rewrite_report.full_rewritten_text,
-                article_id=f"{article_id}_pass2",
-            )
-
         with st.expander("Second-Pass Audit"):
-            if not pass2_report.flagged_sentences:
+            if not result.pass2.flagged_sentences:
                 st.success("No surviving patterns. Rewrite is clean.")
             else:
-                st.warning(f"{pass2_report.flag_count} pattern(s) survived the rewrite:")
-                _render_flagged_sentences(pass2_report.flagged_sentences)
+                st.warning(f"{result.pass2.flag_count} pattern(s) survived the rewrite:")
+                _render_flagged_sentences(result.pass2.flagged_sentences)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,121 @@
+from unittest.mock import call, patch
+
+from src.schemas.audit import AuditReport
+from src.schemas.lexical import LexicalSummary
+from src.schemas.rewrite import RewriteReport
+
+
+def _empty_audit(article_id: str) -> AuditReport:
+    return AuditReport(
+        article_id=article_id,
+        model="mistral",
+        verdict="patch",
+        flag_count=0,
+        category_count=0,
+        lexical_summary=LexicalSummary(tier_1_hits=[], tier_2_clusters=[], tier_3_density=0.0),
+        sub_reports={},
+        flagged_sentences=[],
+    )
+
+
+def _empty_rewrite(article_id: str) -> RewriteReport:
+    return RewriteReport(
+        article_id=article_id,
+        model="mistral",
+        rewrites=[],
+        full_rewritten_text="Rewritten article text.",
+    )
+
+
+def test_run_detect_only_returns_pipeline_result():
+    from src.pipeline import PipelineResult, run_detect_only
+
+    text = "Clean article text."
+    mock_audit = _empty_audit("placeholder")
+
+    with patch("src.pipeline.AuditorAgent") as MockAuditor:
+        mock_instance = MockAuditor.return_value
+        mock_instance.run.return_value = mock_audit
+
+        result = run_detect_only(text=text, model="mistral")
+
+    assert isinstance(result, PipelineResult)
+    assert result.pass1 is mock_audit
+    assert result.rewrite is None
+    assert result.pass2 is None
+    assert isinstance(result.article_id, str)
+    assert len(result.article_id) == 8
+
+
+def test_run_detect_only_calls_auditor_once():
+    from src.pipeline import run_detect_only
+
+    text = "Clean article text."
+    mock_audit = _empty_audit("placeholder")
+
+    with patch("src.pipeline.AuditorAgent") as MockAuditor:
+        mock_instance = MockAuditor.return_value
+        mock_instance.run.return_value = mock_audit
+
+        result = run_detect_only(text=text, model="mistral")
+
+    MockAuditor.assert_called_once_with(model="mistral")
+    mock_instance.run.assert_called_once_with(text=text, article_id=result.article_id)
+
+
+def test_run_full_pipeline_returns_all_fields_populated():
+    from src.pipeline import PipelineResult, run_full_pipeline
+
+    text = "Clean article text."
+    mock_pass1 = _empty_audit("placeholder")
+    mock_rewrite = _empty_rewrite("placeholder")
+    mock_pass2 = _empty_audit("placeholder")
+
+    with patch("src.pipeline.AuditorAgent") as MockAuditor, \
+         patch("src.pipeline.RewriterAgent") as MockRewriter:
+
+        mock_auditor_instance = MockAuditor.return_value
+        mock_auditor_instance.run.side_effect = [mock_pass1, mock_pass2]
+
+        mock_rewriter_instance = MockRewriter.return_value
+        mock_rewriter_instance.run.return_value = mock_rewrite
+
+        result = run_full_pipeline(text=text, model="mistral")
+
+    assert isinstance(result, PipelineResult)
+    assert result.pass1 is mock_pass1
+    assert result.rewrite is mock_rewrite
+    assert result.pass2 is mock_pass2
+    assert isinstance(result.article_id, str)
+    assert len(result.article_id) == 8
+
+
+def test_run_full_pipeline_calls_auditor_twice_rewriter_once():
+    from src.pipeline import run_full_pipeline
+
+    text = "Clean article text."
+    mock_pass1 = _empty_audit("placeholder")
+    mock_rewrite = _empty_rewrite("placeholder")
+    mock_pass2 = _empty_audit("placeholder")
+
+    with patch("src.pipeline.AuditorAgent") as MockAuditor, \
+         patch("src.pipeline.RewriterAgent") as MockRewriter:
+
+        mock_auditor_instance = MockAuditor.return_value
+        mock_auditor_instance.run.side_effect = [mock_pass1, mock_pass2]
+
+        mock_rewriter_instance = MockRewriter.return_value
+        mock_rewriter_instance.run.return_value = mock_rewrite
+
+        result = run_full_pipeline(text=text, model="mistral")
+
+    MockAuditor.assert_called_once_with(model="mistral")
+    MockRewriter.assert_called_once_with(model="mistral")
+    calls = mock_auditor_instance.run.call_args_list
+    assert calls[0] == call(text=text, article_id=result.article_id)
+    assert calls[1] == call(text=mock_rewrite.full_rewritten_text, article_id=f"{result.article_id}_pass2")
+    mock_rewriter_instance.run.assert_called_once_with(
+        flagged_sentences=mock_pass1.flagged_sentences,
+        article_id=result.article_id,
+        original_text=text,
+    )


### PR DESCRIPTION
Closes #10

## Summary
- New `src/pipeline.py`: `PipelineResult` dataclass + `run_detect_only` + `run_full_pipeline`
- Driver owns `article_id` generation (MD5 hash of text content, unified across CLI and UI)
- `review.py`: removed direct agent instantiation and `_article_id` helper — thin I/O wrapper
- `src/ui/app.py`: same refactor — thin presentation wrapper
- New `tests/test_pipeline.py`: 4 unit tests (mocked agents, no Ollama required)

## Test plan
- [x] `uv run pytest -v` — 53 tests pass
- [ ] `uv run python review.py --file <article> --model mistral` — CLI works end-to-end
- [ ] `uv run streamlit run src/ui/app.py` — UI works end-to-end